### PR TITLE
feat: add decision parsing and templates

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -114,6 +114,13 @@
 - The persistence layer preserves the host file’s newline convention when inserting scaffolds on Unix-like systems (macOS and Linux), which are the officially supported platforms; Windows carriage-return handling is currently out of scope.
 - Future configuration may allow custom marker strings, but the default behaviour assumes the canonical markers for maximum interoperability.
 
+### 4.8 Decision Parsing
+- Each decision entry is detected via the canonical `### <ID> <Title>` heading followed by the four bullet-labelled fields (`Status`, `Decision`, `Context`, `Consequences`). The parser tolerates additional blank lines but requires the canonical labels to guarantee a consistent round-trip format.
+- Parsed data is materialised into a structured `DecisionRecord` (powered by Pydantic) that retains ID, title, status, narrative fields, and the raw markdown snippet, enabling edits, reordering, and faithful re-serialization.
+- Multiline field bodies are preserved verbatim; when decisions are rendered back into the marker block, the serializer emits the canonical layout using the file’s prevailing newline sequence to reduce diff churn.
+- Parser utilities raise descriptive `DecisionParseError` exceptions when required fields are missing or malformed so the UI can surface actionable errors before any writes occur.
+- Helper functions compute the next decision identifier and integrate with the template/status helpers to seed new entries with curated status options and sensible defaults.
+
 ---
 
 ## 5. Data Structures

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -81,10 +81,10 @@ vrdx = "vrdx.main:main"
   triggered only when markers missing.
 
 ### Milestone 3 – Decision Parsing and Serialization
-- `decisions.py`: parse decisions from marker regions using regex/Markdown AST.
+- `decisions.py`: parse decisions from marker regions into structured `DecisionRecord` (Pydantic) models that retain IDs, titles, statuses, narrative fields, and the original markdown slice.
 - `template.py`: generate next ID, default status, and stub sections.
-- Round-trip serialization (insert new, reorder, delete) implemented centrally.
-- `status_links.py`: maintain supersedes/deprecated cross references.
+- Round-trip serialization (insert new, reorder, delete) implemented centrally, preserving the host file’s newline style when regenerating the decision block.
+- `status_links.py`: maintain supersedes/deprecated cross references and surface descriptive `DecisionParseError` messages when the canonical fields are missing or malformed.
 - Add documentation snippet describing marker block structure and parsing assumptions.
 - Unit tests with fixture files covering parsing edge cases and serialization.
 

--- a/tests/unit/test_decisions.py
+++ b/tests/unit/test_decisions.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from vrdx.parser import (
+    DecisionParseError,
+    DecisionRecord,
+    find_next_decision_id,
+    parse_decisions,
+    render_decisions,
+    update_decision_body,
+)
+
+
+def test_parse_single_decision():
+    body = (
+        "### 1 Adopt Tool\n"
+        "* **Status**: 📝 Draft\n"
+        "* **Decision**: Use the new tool.\n"
+        "* **Context**: Simpler workflow.\n"
+        "* **Consequences**: Less maintenance.\n"
+    )
+
+    decisions = parse_decisions(body)
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.id == 1
+    assert decision.title == "Adopt Tool"
+    assert decision.status == "📝 Draft"
+    assert "Use the new tool." in decision.decision
+
+
+def test_parse_multiple_decisions_preserves_order():
+    body = (
+        "### 3 Upgrade Stack\n"
+        "* **Status**: ✅ Accepted\n"
+        "* **Decision**: Upgrade to latest stack.\n"
+        "* **Context**: Align with company standards.\n"
+        "* **Consequences**: Training required.\n"
+        "\n"
+        "### 2 Sunset Legacy\n"
+        "* **Status**: ❌ Rejected\n"
+        "* **Decision**: Drop the legacy module.\n"
+        "* **Context**: Customers still depend on it.\n"
+        "* **Consequences**: Revisit next quarter.\n"
+    )
+
+    decisions = parse_decisions(body)
+    assert [d.id for d in decisions] == [3, 2]
+    assert decisions[0].title == "Upgrade Stack"
+    assert decisions[1].status == "❌ Rejected"
+
+
+def test_parse_decision_missing_field_raises():
+    body = (
+        "### 5 Incomplete Decision\n"
+        "* **Status**: 📝 Draft\n"
+        "* **Decision**: TBD\n"
+        "* **Context**: TBD\n"
+    )
+
+    with pytest.raises(DecisionParseError):
+        parse_decisions(body)
+
+
+def test_render_decisions_roundtrip():
+    decisions = [
+        DecisionRecord(
+            id=10,
+            title="Test Decision",
+            status="✅ Accepted",
+            decision="Do the thing.",
+            context="Because it helps.",
+            consequences="Improved morale.",
+            raw="",
+        )
+    ]
+    rendered = render_decisions(decisions)
+    assert "### 10 Test Decision" in rendered
+    reparsed = parse_decisions(rendered)
+    assert reparsed[0].context == "Because it helps."
+
+
+def test_update_decision_body_inserts_newline():
+    decisions = [
+        DecisionRecord(
+            id=1,
+            title="Example",
+            status="📝 Draft",
+            decision="Initial choice.",
+            context="Evaluating options.",
+            consequences="Requires follow-up.",
+            raw="",
+        ),
+        DecisionRecord(
+            id=0,
+            title="Prior Decision",
+            status="✅ Accepted",
+            decision="Baseline.",
+            context="Historical context.",
+            consequences="Already in place.",
+            raw="",
+        ),
+    ]
+    body = update_decision_body("ignored", decisions)
+    assert body.endswith("\n")
+    assert body.count("###") == 2
+
+
+def test_find_next_decision_id_returns_increment():
+    decisions = [
+        DecisionRecord(
+            id=7,
+            title="Existing",
+            status="✅ Accepted",
+            decision="Existing decision.",
+            context="Already decided.",
+            consequences="Stable.",
+            raw="",
+        )
+    ]
+    assert find_next_decision_id(decisions) == 8
+    assert find_next_decision_id([]) == 0

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+from vrdx.parser import (
+    DEFAULT_STATUS,
+    DecisionTemplate,
+    list_status_options,
+    normalise_status,
+    render_template,
+)
+
+
+def test_render_template_uses_defaults():
+    output = render_template(42)
+    assert output.startswith("### 42")
+    assert f"* **Status**: {DEFAULT_STATUS}" in output
+    assert "* **Decision**:" in output
+    assert "* **Context**:" in output
+    assert "* **Consequences**:" in output
+
+
+def test_render_template_accepts_custom_values():
+    output = render_template(
+        5,
+        title="Evaluate New Shell",
+        status="✅ Accepted",
+        decision="Adopt nushell for daily work.",
+        context="Prefer structured pipelines.",
+        consequences="Need to migrate dotfiles.",
+    )
+    lines = output.splitlines()
+    assert lines[0] == "### 5 Evaluate New Shell"
+    assert lines[1].endswith("✅ Accepted")
+    assert "Adopt nushell for daily work." in lines[2]
+    assert "Prefer structured pipelines." in lines[3]
+    assert "Need to migrate dotfiles." in lines[4]
+
+
+def test_decision_template_render_matches_function():
+    template = DecisionTemplate(
+        next_id=3,
+        title_placeholder="Review Terminal Options",
+        status="❌ Rejected",
+        decision_placeholder="Do not switch terminals.",
+        context_placeholder="Ghostty already fits needs.",
+        consequences_placeholder="No further action required.",
+    )
+    assert template.render() == render_template(
+        3,
+        title="Review Terminal Options",
+        status="❌ Rejected",
+        decision="Do not switch terminals.",
+        context="Ghostty already fits needs.",
+        consequences="No further action required.",
+    )
+
+
+def test_list_status_options_contains_default():
+    options = list(list_status_options())
+    assert DEFAULT_STATUS in options
+    assert len(options) == len(set(options))  # no duplicates
+    assert options == list_status_options()  # deterministic ordering
+
+
+@pytest.mark.parametrize(
+    ("input_status", "expected"),
+    [
+        ("✅ Accepted", "✅ Accepted"),
+        ("📝 Draft", "📝 Draft"),
+        ("Unknown Status", DEFAULT_STATUS),
+    ],
+)
+def test_normalise_status(input_status: str, expected: str):
+    assert normalise_status(input_status) == expected

--- a/vrdx/parser/__init__.py
+++ b/vrdx/parser/__init__.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from . import markers
+from . import decisions, markers, template
+from .decisions import (
+    DecisionParseError,
+    DecisionRecord,
+    find_next_decision_id,
+    parse_decisions,
+    render_decisions,
+    update_decision_body,
+)
 from .markers import (
     MARKER_END,
     MARKER_START,
@@ -16,9 +24,18 @@ from .markers import (
     detect_preferred_newline,
     ensure_marker_block,
 )
+from .template import (
+    DEFAULT_STATUS,
+    DecisionTemplate,
+    list_status_options,
+    normalise_status,
+    render_template,
+)
 
-__all__ = [
+__all__ = (
+    "decisions",
     "markers",
+    "template",
     "MARKER_END",
     "MARKER_START",
     "MarkerBlock",
@@ -30,4 +47,15 @@ __all__ = [
     "detect_marker_block",
     "detect_preferred_newline",
     "ensure_marker_block",
-]
+    "DecisionRecord",
+    "DecisionParseError",
+    "parse_decisions",
+    "render_decisions",
+    "update_decision_body",
+    "find_next_decision_id",
+    "DEFAULT_STATUS",
+    "DecisionTemplate",
+    "render_template",
+    "list_status_options",
+    "normalise_status",
+)

--- a/vrdx/parser/decisions.py
+++ b/vrdx/parser/decisions.py
@@ -1,0 +1,177 @@
+"""Parsing and serialising decision records enclosed within vrdx marker blocks.
+
+This module focuses on Milestone 3 responsibilities: extracting structured
+decision data from Markdown and rendering it back while preserving a consistent
+format. Decisions are expected to follow the canonical template documented in
+``docs/DESIGN.md``:
+
+    ### 13 Sticking with Amethyst
+    * **Status**: ✅ Adopted
+    * **Decision**: ...
+    * **Context**: ...
+    * **Consequences**: ...
+
+Multiple decisions can appear inside a single marker block. The parser is
+designed to be resilient to additional whitespace and multiline field content,
+but it assumes that headings start with ``###`` and field labels remain
+canonical.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+from pydantic import BaseModel, Field, field_validator
+
+HEADING_PATTERN = re.compile(r"^###\s+(?P<id>\d+)\s+(?P<title>.+)$", re.MULTILINE)
+FIELD_PATTERN = re.compile(
+    r"^\*\s+\*\*(?P<label>Status|Decision|Context|Consequences)\*\*:\s*(?P<value>.*)$"
+)
+
+CANONICAL_FIELDS: tuple[str, ...] = ("Status", "Decision", "Context", "Consequences")
+FIELD_TO_ATTR = {
+    "Status": "status",
+    "Decision": "decision",
+    "Context": "context",
+    "Consequences": "consequences",
+}
+
+
+class DecisionParseError(ValueError):
+    """Raised when a decision block cannot be parsed into the expected format."""
+
+
+class DecisionRecord(BaseModel):
+    """Structured representation of a single decision entry."""
+
+    id: int = Field(gt=-1)
+    title: str
+    status: str
+    decision: str
+    context: str
+    consequences: str
+    raw: str = Field(repr=False)
+
+    @field_validator("title", "status", "decision", "context", "consequences")
+    @classmethod
+    def _trim(cls, value: str) -> str:  # pragma: no cover - trivial helper
+        return value.strip()
+
+    def render(self, *, newline: str = "\n") -> str:
+        """Render the decision back to Markdown using the canonical format."""
+        parts = [
+            f"### {self.id} {self.title}",
+            f"* **Status**: {self.status}",
+            f"* **Decision**: {self.decision}",
+            f"* **Context**: {self.context}",
+            f"* **Consequences**: {self.consequences}",
+        ]
+        return newline.join(parts)
+
+
+def _iter_decision_sections(body: str) -> Iterator[str]:
+    matches = list(HEADING_PATTERN.finditer(body))
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        section = body[start:end].strip()
+        if section:
+            yield section
+
+
+def _extract_field_blocks(lines: Sequence[str]) -> dict[str, str]:
+    """Convert bullet-field lines into a mapping from label to value."""
+    result = {field: "" for field in CANONICAL_FIELDS}
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        match = FIELD_PATTERN.match(line.strip())
+        if not match:
+            idx += 1
+            continue
+
+        label = match.group("label")
+        buffer: List[str] = [match.group("value").rstrip()]
+        idx += 1
+
+        while idx < len(lines):
+            candidate = lines[idx]
+            # Stop when we hit another field bullet or a heading.
+            if FIELD_PATTERN.match(candidate.strip()) or candidate.startswith("### "):
+                break
+            buffer.append(candidate.rstrip())
+            idx += 1
+
+        result[label] = "\n".join(part for part in buffer if part).strip()
+    return result
+
+
+def parse_decisions(body: str) -> list[DecisionRecord]:
+    """Parse all decisions contained in a marker block body."""
+    decisions: list[DecisionRecord] = []
+    for section in _iter_decision_sections(body):
+        lines = section.splitlines()
+        if not lines:
+            continue
+
+        heading_match = HEADING_PATTERN.match(lines[0])
+        if not heading_match:
+            raise DecisionParseError(f"Missing decision heading in block:\n{section}")
+
+        decision_id = int(heading_match.group("id"))
+        title = heading_match.group("title").strip()
+
+        field_map = _extract_field_blocks(lines[1:])
+        missing = [field for field in CANONICAL_FIELDS if not field_map[field]]
+        if missing:
+            raise DecisionParseError(
+                f"Decision {decision_id} '{title}' is missing fields: {', '.join(missing)}"
+            )
+
+        decisions.append(
+            DecisionRecord(
+                id=decision_id,
+                title=title,
+                status=field_map["Status"],
+                decision=field_map["Decision"],
+                context=field_map["Context"],
+                consequences=field_map["Consequences"],
+                raw=section,
+            )
+        )
+    return decisions
+
+
+def render_decisions(
+    decisions: Iterable[DecisionRecord],
+    *,
+    newline: str = "\n",
+    separator: Optional[str] = None,
+) -> str:
+    """Render an iterable of decisions back into Markdown."""
+    sep = separator if separator is not None else f"{newline}{newline}"
+    rendered = [decision.render(newline=newline) for decision in decisions]
+    return sep.join(rendered)
+
+
+def find_next_decision_id(decisions: Sequence[DecisionRecord]) -> int:
+    """Return the next available decision ID, counting downwards from the maximum."""
+    if not decisions:
+        return 0
+    return max(decision.id for decision in decisions) + 1
+
+
+def update_decision_body(
+    existing_body: str,
+    decisions: Sequence[DecisionRecord],
+    *,
+    newline: str = "\n",
+) -> str:
+    """Replace the decision block body with the given decisions."""
+    rendered = render_decisions(
+        decisions, newline=newline, separator=f"{newline}{newline}"
+    )
+    if rendered and not rendered.endswith(newline):
+        rendered = f"{rendered}{newline}"
+    return rendered

--- a/vrdx/parser/template.py
+++ b/vrdx/parser/template.py
@@ -1,0 +1,84 @@
+"""Helpers for generating decision templates and status metadata.
+
+This module centralises the canonical template content used when creating new
+decision records. It also exposes the curated set of status labels surfaced in
+the UI so both the renderer and the interface share a single source of truth.
+
+The template output mirrors the structure documented in `docs/DESIGN.md`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+DEFAULT_STATUS = "📝 Draft"
+
+# Ordered list so the UI can present statuses predictably.
+STATUS_OPTIONS: List[str] = [
+    "📝 Draft",
+    "✅ Accepted",
+    "❌ Rejected",
+    "⛔ Deprecated by …",
+    "⬆️ Supersedes …",
+]
+
+
+@dataclass(frozen=True)
+class DecisionTemplate:
+    """Callable container for producing new decision Markdown blocks."""
+
+    next_id: int
+    title_placeholder: str = ""
+    status: str = DEFAULT_STATUS
+    decision_placeholder: str = ""
+    context_placeholder: str = ""
+    consequences_placeholder: str = ""
+
+    def render(self, *, newline: str = "\n") -> str:
+        """Render the decision template using the specified newline."""
+        parts = [
+            f"### {self.next_id} {self.title_placeholder}".rstrip(),
+            f"* **Status**: {self.status}",
+            f"* **Decision**: {self.decision_placeholder}",
+            f"* **Context**: {self.context_placeholder}",
+            f"* **Consequences**: {self.consequences_placeholder}",
+        ]
+        return newline.join(parts)
+
+
+def is_status_supported(status: str) -> bool:
+    """Return True when ``status`` is one of the curated status options."""
+    return status in STATUS_OPTIONS
+
+
+def normalise_status(status: str) -> str:
+    """Return the provided status when it is supported; otherwise, fall back to the default draft status."""
+    return status if is_status_supported(status) else DEFAULT_STATUS
+
+
+def render_template(
+    next_id: int,
+    *,
+    title: str = "",
+    status: str = DEFAULT_STATUS,
+    decision: str = "",
+    context: str = "",
+    consequences: str = "",
+    newline: str = "\n",
+) -> str:
+    """Convenience function to create and render a decision template."""
+    template = DecisionTemplate(
+        next_id=next_id,
+        title_placeholder=title,
+        status=normalise_status(status),
+        decision_placeholder=decision,
+        context_placeholder=context,
+        consequences_placeholder=consequences,
+    )
+    return template.render(newline=newline)
+
+
+def list_status_options() -> Iterable[str]:
+    """Return the curated status values."""
+    return STATUS_OPTIONS


### PR DESCRIPTION
# Summary
- add decision parsing utilities that transform marker block content into structured records and render them back consistently
- introduce template helpers for curated statuses and default new decision scaffolds
- update documentation and tests to cover the parsing workflow and template behaviour

# Testing
- uv run --with pytest pytest
