### PR TITLE
feat: add editable TextArea and save flow

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -130,7 +130,7 @@
 - The first Textual iteration renders the four-pane layout described earlier: a narrow left column that stacks the decision list above the markdown file list, a dominant editor pane centered on the screen, and a preview pane to the right. Each pane is addressable by numeric shortcuts (`1`–`4`) and clearly labelled in the header bar.
 - Navigation bindings mirror the lazygit-inspired interaction model (`j/k` or arrow keys for movement, `space` to activate a selection, `?` for the key reference overlay), while the footer reflects the current save state indicator (`● Saved` / `● Unsaved`) and the most important actions (`[n]ew`, `[s]ave`, `[q]uit`, `[?]help`).
 - The editor pane now leverages Textual's `TextArea`, remaining read-only while browsing but switching to an editable buffer when a user activates `space` or drafts a new decision via `n`, seeding the template directly into the cursor.
-- The preview pane and state wiring continue to stay in sync so that moving between files or decisions immediately updates both editor and preview content; future milestones will layer in status pickers and mutation workflows.
+- The preview pane and state wiring continue to stay in sync so that moving between files or decisions immediately updates both editor and preview content; in this milestone the `p` binding simply cycles through the curated status set and `s` writes the updated decision back to the underlying markdown file. A richer status picker, Markdown-rendered preview, and in-app reordering/deletion flows remain on the roadmap for the next iteration.
 
 ---
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -102,12 +102,8 @@ vrdx = "vrdx.main:main"
 - `ui/styles.tcss`: initial stylesheet to lay out the left column, editor, and preview panes (added).
 
 ### Milestone 6 – Editor and Preview Features
-- Upgrade the editor pane to a Textual `TextArea`, toggling between read-only inspection and editable mode when the user drafts a new decision or opens an existing one.
-- Introduce status selection and validation (picker modal or inline palette) so curated icons stay in sync with cross-links.
-- Enhance the right-hand preview to render Markdown (via `markdown-it-py`) and reflect in-progress edits in real time.
-- Support interactive decision mutations: reorder with `J/K`, delete with `d`, and surface confirmations.
-- Implement persistence triggers (`s` for save, status bar feedback) that write the marker block back to disk through the command layer.
-- Extend the `n` flow to insert template content directly into the editor, positioning the cursor for immediate editing.
+- **Implemented**: Upgraded the editor pane to a Textual `TextArea`, allowing read-only browsing versus editable drafts, seeding new decision templates, and wiring the save flow (`s`) through the command layer with status feedback.
+- **Remaining**: Add curated status selection UI, render the preview pane with live Markdown, and support in-app reordering/deletion (`J/K`, `d`) with confirmations.
 
 ### Milestone 7 – Polish and Packaging
 - Visual polish: highlight active pane, ensure colors accessible.

--- a/vrdx/app/commands.py
+++ b/vrdx/app/commands.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Iterable, Optional
+from typing import Iterable, Literal, Optional
 
 from vrdx.app.state import AppState, DecisionLink, DecisionState, FileState, PaneId
 from vrdx.parser import (

--- a/vrdx/ui/app.py
+++ b/vrdx/ui/app.py
@@ -9,11 +9,14 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.reactive import reactive
-
 from textual.widgets import Footer, Header, Label, ListItem, ListView, Static, TextArea
 
 from vrdx.app import commands
+from vrdx.app.persistence import read_markdown, write_markdown
 from vrdx.app.state import AppState, FileState, PaneId
+from vrdx.parser import DecisionParseError, list_status_options, parse_decisions
+from vrdx.parser.markers import ensure_marker_block
+from vrdx.parser.template import render_template
 
 
 @dataclass
@@ -41,10 +44,9 @@ class FileList(ListView):
 
     def populate(self, files: Iterable[FileState], selected: int) -> None:
         self.clear()
-        for index, file_state in enumerate(files):
+        for file_state in files:
             label = file_state.path.relative_to(file_state.path.parents[0])
-            item = ListItem(Label(str(label)))
-            self.append(item)
+            self.append(ListItem(Label(str(label))))
         if self.children and 0 <= selected < len(self.children):
             self.index = selected
 
@@ -57,13 +59,13 @@ class PreviewPane(Static):
 
 
 class EditorPane(TextArea):
-    """Editable text area for composing or updating decisions."""
+    """Editable text area used for drafting decisions."""
 
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__(placeholder="Draft decision content…", id=id)
         self.read_only = True
 
-    def set_content(self, content: str, editable: bool = False) -> None:
+    def set_content(self, content: str, *, editable: bool = False) -> None:
         self.value = content or ""
         self.cursor_position = len(self.value)
         self.read_only = not editable
@@ -81,10 +83,13 @@ class VrdxApp(App[None]):
         Binding("4", "focus_files", "Files", show=False),
         Binding("j,down", "next_decision", "Next decision", show=False),
         Binding("k,up", "previous_decision", "Previous decision", show=False),
-        Binding("space", "select_decision", "Select decision", show=False),
+        Binding("space", "select_decision", "Edit", show=True),
+        Binding("n", "new_decision", "New", show=True),
+        Binding("p", "pick_status", "Status", show=True),
+        Binding("s", "save", "Save", show=True),
         Binding("r", "refresh", "Refresh", show=False),
-        Binding("?", "show_help", "Help", show=False),
-        Binding("q", "quit", "Quit vrdx", show=True),
+        Binding("?", "show_help", "Help", show=True),
+        Binding("q", "quit", "Quit", show=True),
     ]
 
     app_state: AppState
@@ -97,6 +102,10 @@ class VrdxApp(App[None]):
         self._file_list: Optional[FileList] = None
         self._preview: Optional[PreviewPane] = None
         self._editor: Optional[EditorPane] = None
+        self._editor_mode: str = "view"
+        self._editing_decision_id: Optional[int] = None
+        self._status_options = list(list_status_options())
+        self._status_message: str = ""
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -116,8 +125,8 @@ class VrdxApp(App[None]):
             yield Footer()
 
     def on_mount(self) -> None:
-        self.refresh_panes()
         self.focus_pane(PaneId.DECISIONS)
+        self.refresh_panes()
 
     def refresh_panes(self) -> None:
         file_state = self.app_state.current_file()
@@ -129,24 +138,26 @@ class VrdxApp(App[None]):
                 self.app_state.files, self.app_state.selected_file_index
             )
         self.refresh_preview()
-        self.refresh_editor()
+        if self._editor_mode == "view":
+            self.refresh_editor()
         self.update_dirty_indicator()
+        self._update_footer()
 
     def refresh_preview(self) -> None:
         decision_state = self.app_state.current_decision()
         if self._preview:
-            content = decision_state.record.raw if decision_state else ""
+            content = decision_state.record.render() if decision_state else ""
             self._preview.show_decision(content)
 
     def refresh_editor(self) -> None:
+        if not self._editor:
+            return
         decision_state = self.app_state.current_decision()
-        if self._editor:
-            editable = False
-            if decision_state:
-                rendered = decision_state.record.render()
-            else:
-                rendered = "Select a decision to edit."
-            self._editor.set_content(rendered, editable)
+        if decision_state:
+            rendered = decision_state.record.render()
+        else:
+            rendered = "Select a decision to edit."
+        self._editor.set_content(rendered, editable=False)
 
     def update_dirty_indicator(self) -> None:
         self.dirty_indicator = "● Unsaved" if self.app_state.is_modified else "● Saved"
@@ -182,32 +193,165 @@ class VrdxApp(App[None]):
 
     def action_next_decision(self) -> None:
         commands.focus_next_decision(self.app_state)
+        self._reset_edit_state()
         self.refresh_panes()
 
     def action_previous_decision(self) -> None:
         commands.focus_previous_decision(self.app_state)
+        self._reset_edit_state()
         self.refresh_panes()
 
     def action_select_decision(self) -> None:
+        self._begin_edit_existing()
+
+    def action_new_decision(self) -> None:
         file_state = self.app_state.current_file()
-        if not self._editor or file_state is None:
+        if not file_state or not self._editor:
             return
-
-        decision_state = self.app_state.current_decision()
-        if decision_state:
-            content = decision_state.record.render()
-        else:
-            content = commands.apply_template_to_editor(file_state.next_decision_id())
-
-        self._editor.set_content(content, editable=True)
+        template = render_template(file_state.next_decision_id())
+        self._editor_mode = "edit-new"
+        self._editing_decision_id = None
+        self._status_message = "Drafting new decision"
+        self._editor.set_content(template, editable=True)
         self.focus_pane(PaneId.EDITOR)
+        self._update_footer()
+
+    def action_pick_status(self) -> None:
+        if not self._editor or self._editor.read_only:
+            return
+        try:
+            record = self._parse_editor_record()
+        except DecisionParseError as exc:
+            self._show_message(f"Status change failed: {exc}")
+            return
+        try:
+            current_index = self._status_options.index(record.status)
+            next_status = self._status_options[
+                (current_index + 1) % len(self._status_options)
+            ]
+        except ValueError:
+            next_status = self._status_options[0]
+        lines = self._editor.value.splitlines()
+        for idx, line in enumerate(lines):
+            if line.startswith("* **Status**:"):
+                lines[idx] = f"* **Status**: {next_status}"
+                break
+        self._editor.set_content("\n".join(lines), editable=True)
+
+    def action_save(self) -> None:
+        if not self._editor or self._editor.read_only:
+            return
+        try:
+            record = self._parse_editor_record()
+        except DecisionParseError as exc:
+            self._show_message(f"Unable to save: {exc}")
+            return
+        if self._editor_mode == "edit-new":
+            commands.create_decision(
+                self.app_state,
+                title=record.title,
+                decision=record.decision,
+                context=record.context,
+                consequences=record.consequences,
+                status=record.status,
+            )
+            self.app_state.selected_decision_index = 0
+        elif (
+            self._editor_mode == "edit-existing"
+            and self._editing_decision_id is not None
+        ):
+            commands.update_decision(
+                self.app_state,
+                decision_id=self._editing_decision_id,
+                title=record.title,
+                status=record.status,
+                decision_text=record.decision,
+                context=record.context,
+                consequences=record.consequences,
+            )
+        else:
+            self._show_message("Nothing to save.")
+            return
+        self._persist_current_file()
+        self._status_message = "Saved"
+        self._reset_edit_state()
+        self.refresh_panes()
 
     def action_refresh(self) -> None:
+        self._reset_edit_state()
         self.refresh_panes()
 
     def action_show_help(self) -> None:
-        self.push_screen(Static("Key bindings:\n" + "\n".join(self.help_actions())))
+        help_lines = [
+            "[space] edit",
+            "[n] new decision",
+            "[p] cycle status",
+            "[s] save",
+            "[q] quit",
+            "[?] help",
+        ]
+        self.push_screen(
+            Static("Key bindings:\n" + "\n".join(f"- {line}" for line in help_lines))
+        )
 
     def watch_dirty_indicator(self, dirty_indicator: str) -> None:
+        self._update_footer()
+
+    def _begin_edit_existing(self) -> None:
+        if not self._editor:
+            return
+        decision_state = self.app_state.current_decision()
+        if not decision_state:
+            return
+        self._editor_mode = "edit-existing"
+        self._editing_decision_id = decision_state.record.id
+        self._status_message = f"Editing decision #{decision_state.record.id}"
+        self._editor.set_content(decision_state.record.render(), editable=True)
+        self.focus_pane(PaneId.EDITOR)
+        self._update_footer()
+
+    def _parse_editor_record(self):
+        if not self._editor:
+            raise DecisionParseError("Editor unavailable.")
+        content = self._editor.value
+        records = parse_decisions(content)
+        if len(records) != 1:
+            raise DecisionParseError("Editor must contain exactly one decision entry.")
+        return records[0]
+
+    def _persist_current_file(self) -> None:
+        file_state = self.app_state.current_file()
+        if not file_state:
+            return
+        try:
+            original_text = read_markdown(file_state.path)
+        except FileNotFoundError:
+            original_text = ""
+        updated_text, block, _ = ensure_marker_block(original_text)
+        body = commands.serialize_current_file(self.app_state)
+        if body and not body.endswith("\n"):
+            body += "\n"
+        new_text = block.replace_body(updated_text, body)
+        write_markdown(file_state.path, new_text)
+        self.app_state.mark_saved()
+
+    def _reset_edit_state(self) -> None:
+        self._editor_mode = "view"
+        self._editing_decision_id = None
+        self._status_message = ""
+        self.refresh_editor()
+        self._update_footer()
+
+    def _show_message(self, message: str) -> None:
+        self._status_message = message
+        self.log(message)
+        self._update_footer()
+
+    def _update_footer(self) -> None:
         if footer := self.query_one(Footer):
-            footer.add_text(dirty_indicator)
+            hint_text = (
+                "[space] edit  [n] new  [p] status  [s] save  [q] quit  [?] help"
+            )
+            footer.update(
+                f"{self.dirty_indicator}  {self._status_message or hint_text}"
+            )


### PR DESCRIPTION
# Summary
- upgrade the Textual editor pane to a TextArea with edit/view modes, template seeding, and status cycling
- wire save (`s`) and status (`p`) interactions through the command layer, persisting decisions back to markdown markers and updating footer hints
- refresh design/implementation docs to capture the current editor capabilities and note remaining roadmap items

# Testing
- uv run --with pytest pytest
